### PR TITLE
Fix pointer‑type warning in start_write()

### DIFF
--- a/zip_file.hpp
+++ b/zip_file.hpp
@@ -5597,7 +5597,7 @@ private:
                 
                 mz_zip_reader_end(archive_.get());
                 
-                archive_->m_pWrite = &detail::write_callback;
+                archive_->m_pWrite = reinterpret_cast<mz_file_write_func>(&detail::write_callback);
                 archive_->m_pIO_opaque = &buffer_;
                 buffer_ = std::vector<char>();
                 
@@ -5625,7 +5625,7 @@ private:
                 break;
         }
 
-        archive_->m_pWrite = &detail::write_callback;
+        archive_->m_pWrite = reinterpret_cast<mz_file_write_func>(&detail::write_callback);
         archive_->m_pIO_opaque = &buffer_;
 
         if(!mz_zip_writer_init(archive_.get(), 0))


### PR DESCRIPTION
Cast detail::write_callback to mz_file_write_func to silence the “incompatible pointer type” error.